### PR TITLE
ci: run jobs in hackflare-builder image for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,14 @@ env:
   MIX_ENV: test
   ELIXIR_VERSION: '1.19'
   OTP_VERSION: '27.0'
+  # Point Mix/Hex/Rebar at the locations populated when the builder image
+  # was built (as root). GitHub Actions overrides HOME to /github/home for
+  # container jobs, so without these the pre-installed Hex/Rebar archives
+  # under /root/.mix wouldn't be discovered.
+  MIX_HOME: /root/.mix
+  HEX_HOME: /root/.hex
+  REBAR_GLOBAL_CONFIG_DIR: /root/.config/rebar3
+  REBAR_CACHE_DIR: /root/.cache/rebar3
 
 jobs:
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,14 +35,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
+      packages: read
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: ghcr.io/hack-flare/hackflare-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
 
       - name: Restore dependencies and build cache
         uses: actions/cache@v5
@@ -68,16 +70,13 @@ jobs:
   compile:
     name: Compile Application
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: ghcr.io/hack-flare/hackflare-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
-
-      - uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
 
       - name: Restore deps cache
         uses: actions/cache@v5
@@ -106,14 +105,14 @@ jobs:
     name: Static Analysis
     needs: [compile, format]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: ghcr.io/hack-flare/hackflare-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
-      - uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
-          
       - uses: actions/cache/restore@v5
         with:
           path: |
@@ -131,13 +130,13 @@ jobs:
     name: Type Checking
     needs: [compile, format]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: ghcr.io/hack-flare/hackflare-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
 
       - name: Restore/Save Dialyzer PLT Cache
         uses: actions/cache@v5
@@ -166,22 +165,33 @@ jobs:
     permissions:
       contents: read
       packages: write
+    container:
+      image: ghcr.io/hack-flare/hackflare-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup-rust
 
       - name: Check Crates
         run: cargo check
 
       - name: Clippy Crates
         run: cargo clippy -- -D warnings
-        
-        
+
+
   test:
     name: Test Partition ${{ matrix.partition }}
     needs: [compile, format]
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: ghcr.io/hack-flare/hackflare-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      DB_HOST: postgres
     strategy:
       fail-fast: false
       matrix:
@@ -203,11 +213,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: erlef/setup-beam@v1
-        with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
-
       - uses: actions/cache/restore@v5
         with:
           path: |
@@ -221,7 +226,7 @@ jobs:
         run: |
           mkdir -p priv/repo/migrations
           mix do app.start + ecto.create + ecto.migrate
-          
+
       - name: Run Tests
         env:
           MIX_TEST_PARTITION: ${{ matrix.partition }}


### PR DESCRIPTION
Each Elixir/Rust job in `ci.yml` was reinstalling OTP/Elixir (via `erlef/setup-beam`) and Rust (via `./.github/actions/setup-rust`) on a bare runner. Since `builder.dockerfile` already publishes `ghcr.io/hack-flare/hackflare-builder:latest` with Elixir 1.19, OTP 27, Rust 1.92, hex/rebar, and primed Hex + cargo registries, this PR moves every job into that container so toolchain setup becomes a no-op.

How it works:
- Adds a `container:` block with GHCR credentials (`${{ github.actor }}` / `${{ secrets.GITHUB_TOKEN }}`) to `format`, `compile`, `static_analysis`, `type_check`, `rust-checks`, and `test`.
- Drops the `erlef/setup-beam@v1` and `./.github/actions/setup-rust` steps from those jobs (still used nowhere else).
- Adds top-level `permissions: packages: read` so the default token can pull the image.
- Sets `DB_HOST: postgres` on the `test` job so Ecto reaches the Postgres service container by service name now that the job itself runs inside a container (the existing `5432:5432` port mapping is left in place; harmless when unused).

The workflow-level `ELIXIR_VERSION` / `OTP_VERSION` env vars are no longer authoritative for the toolchain; they only feed cache keys, so they're left in place. The composite action at `.github/actions/setup-rust` is now unreferenced from CI but kept in-tree to keep this change minimal. First run in any branch will pay a one-time image pull; subsequent runs benefit from Blacksmith's image cache. Image is tracked at `:latest`, which only moves when `docker-builder-build-publish.yml` is intentionally dispatched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hack-Flare/codesmith/hackflare/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->