### PR TITLE
ci: bake PLT, merge analysis, single test job, decouple rust-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
 
   compile:
     name: Compile Application
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Compile is the long pole on the critical path: parallel Elixir compile
+    # plus a Rust NIF build via rustler both benefit from more cores.
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     container:
       image: ghcr.io/hack-flare/hackflare-builder:latest
       credentials:
@@ -95,8 +97,6 @@ jobs:
 
       - name: Compile Elixir + Rust
         run: |
-          mix local.hex --force
-          mix local.rebar --force
           mix deps.get
           mix compile --warnings-as-errors
 
@@ -109,8 +109,12 @@ jobs:
             priv/native
           key: ${{ runner.os }}-build-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ github.sha }}
 
-  static_analysis:
-    name: Static Analysis
+  analysis:
+    # Combined static analysis + dialyzer. Both need the same _build / deps
+    # cache and run inside the same image, so paying container init and cache
+    # restore once is strictly cheaper than splitting them. Dialyzer is mostly
+    # single-threaded; 4vcpu is plenty.
+    name: Analysis
     needs: [compile]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
@@ -120,39 +124,6 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/cache/restore@v5
-        with:
-          path: |
-            deps
-            _build
-            priv/native
-          key: ${{ runner.os }}-build-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ github.sha }}
-          fail-on-cache-miss: true
-
-      - run: mix credo --strict
-      - run: mix deps.audit
-      - run: mix sobelow --config
-
-  type_check:
-    name: Type Checking
-    needs: [compile]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    container:
-      image: ghcr.io/hack-flare/hackflare-builder:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Restore/Save Dialyzer PLT Cache
-        uses: actions/cache@v5
-        with:
-          path: priv/plts
-          key: ${{ runner.os }}-plt-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-plt-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
 
       - name: Restore Application Build
         uses: actions/cache/restore@v5
@@ -164,12 +135,36 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ github.sha }}
           fail-on-cache-miss: true
 
-      - name: Run Dialyzer
-        run: mix dialyzer
+      - name: Restore/Save Dialyzer PLT Cache
+        uses: actions/cache@v5
+        with:
+          path: priv/plts
+          key: ${{ runner.os }}-plt-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-plt-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-
+
+      - name: Seed PLT from builder image baseline
+        # If the cache restore above didn't populate priv/plts (cold cache or
+        # mix.lock changed enough that no restore-key matched), fall back to
+        # the PLT baked into the builder image. Dialyzer will incrementally
+        # update from there, which is much faster than building from scratch.
+        run: |
+          mkdir -p priv/plts
+          if [ -d /opt/plts ] && [ -z "$(ls -A priv/plts 2>/dev/null)" ]; then
+            echo "Seeding PLT from /opt/plts baseline"
+            cp -a /opt/plts/. priv/plts/
+          fi
+
+      - run: mix credo --strict
+      - run: mix deps.audit
+      - run: mix sobelow --config
+      - run: mix dialyzer
 
   rust-checks:
-    needs: [compile]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Independent of `compile`: cargo check / clippy only need the Rust
+    # workspace and the cargo registry primed in the builder image, not the
+    # Elixir build cache. Starting at t=0 gets it off the critical path.
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: write
@@ -187,9 +182,13 @@ jobs:
 
       - name: Clippy Crates
         run: cargo clippy -- -D warnings
-        
+
   test:
-    name: Test Partition ${{ matrix.partition }}
+    # The previous 6-way matrix had each partition running ~1-2 test files,
+    # paying full container init + Postgres spin-up + cache restore + ecto
+    # setup per partition. With ~8 test files total, a single job using
+    # ExUnit's built-in async parallelism is faster end-to-end and cheaper.
+    name: Test
     needs: [compile]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
@@ -199,10 +198,6 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       DB_HOST: postgres
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6]
     services:
       postgres:
         image: postgres:16-alpine
@@ -210,8 +205,6 @@ jobs:
           POSTGRES_USER: hackflare
           POSTGRES_PASSWORD: hackflare
           POSTGRES_DB: hackflare
-        ports:
-          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -235,6 +228,4 @@ jobs:
           mix do app.start + ecto.create + ecto.migrate
 
       - name: Run Tests
-        env:
-          MIX_TEST_PARTITION: ${{ matrix.partition }}
-        run: mix test --partitions 6
+        run: mix test

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -30,10 +30,24 @@ RUN mix local.hex --force && \
 
 WORKDIR /app
 
-# Prime Hex dependencies from the lockfile before app source changes.
+# Prime Hex dependencies from the lockfile (prod env, used for production builds).
 COPY mix.exs mix.lock ./
 COPY config/ ./config/
 RUN mix deps.get
+
+# Bake a Dialyzer PLT into the image so CI's type-check step only has to
+# incrementally analyse project modules and any deps added since this image
+# was built. We need test-env deps (dialyxir lives there) and stub source
+# directories for `mix dialyzer --plt`. The compiled artefacts and stub
+# sources are dropped after the PLT is copied to /opt/plts so they don't
+# bloat the image or surprise downstream consumers.
+RUN mkdir -p lib test/support priv/plts && \
+    MIX_ENV=test mix deps.get && \
+    MIX_ENV=test mix deps.compile && \
+    MIX_ENV=test mix dialyzer --plt && \
+    mkdir -p /opt/plts && \
+    cp -a priv/plts/. /opt/plts/ && \
+    rm -rf lib test priv _build
 
 # Prime Rust crates from the workspace manifests before app source changes.
 COPY Cargo.toml Cargo.lock ./
@@ -43,6 +57,6 @@ RUN mkdir -p native/core/src && \
     touch native/core/src/lib.rs && \
     cargo fetch --locked
 
-RUN elixir -v && rustc --version && cargo --version
+RUN elixir -v && rustc --version && cargo --version && ls /opt/plts
 
 WORKDIR /toolchain


### PR DESCRIPTION
Follow-up to the builder-image migration. After that PR landed, the critical path on a typical run is `compile (~86s) -> type_check (~113s)` ≈ 3m20s, with most of `type_check` being a cold Dialyzer PLT build. This PR attacks every node on that path and trims the rest of the workflow's fixed costs.

How it works:
- `builder.dockerfile` now bakes a baseline Dialyzer PLT (test-env deps + OTP) into `/opt/plts` so the `analysis` job no longer pays for a from-scratch PLT build on cache miss; Dialyzer just incrementally adds project modules and any new deps. The CI job's new "Seed PLT" step copies the baked baseline only when the cache restore yields nothing.
- `static_analysis` and `type_check` are merged into a single `analysis` job. They shared the same `_build`/`deps` cache and image; running them sequentially in one job pays container init + cache restore once instead of twice.
- The 6-way test matrix is collapsed to a single `test` job. With 8 test files total, the matrix was paying full container init, Postgres service spin-up, build-cache restore, and `ecto.create + migrate` six times for what's effectively a few seconds of actual test work per partition. ExUnit's built-in async parallelism handles the fan-out cheaply inside one BEAM.
- `rust-checks` no longer waits on `compile` (it only needs the Rust workspace + the cargo registry already primed in the image), and runs on `blacksmith-8vcpu-ubuntu-2404` since cargo parallelizes well.
- `compile` also moves to `blacksmith-8vcpu-ubuntu-2404` to shorten the long pole; both `mix compile` and the rustler/cargo NIF build saturate cores comfortably.

Note that the PLT baseline only takes effect after the `docker-builder-build-publish.yml` workflow is dispatched to publish a new `:latest` image with the changes to `builder.dockerfile`. Until then, the CI changes are still strictly faster than today (single test job, merged analysis, parallel rust-checks, larger compile/rust runners) and the seed step is a no-op when `/opt/plts` doesn't exist on the older image. Nothing else in CI behavior changes: the same checks run, just packed into fewer jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hack-Flare/codesmith/hackflare/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->