### PR TITLE
Server-side user sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # General API Configuration
 API_BIND_ADDR="0.0.0.0:8080"
 API_DNS_BIND_ADDR="0.0.0.0:5353"
+API_CLIENT_IP_SOURCE="ConnectInfo"
 API_ENVIRONMENT="development"
 API_AUTO_MIGRATE=false
 

--- a/.sqlx/query-481d61859d340afb79d632af2c2c5fd47f57dd90a5c311bffdaf65917a7077ef.json
+++ b/.sqlx/query-481d61859d340afb79d632af2c2c5fd47f57dd90a5c311bffdaf65917a7077ef.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, user_id, ip_address as \"ip_address: IpAddr\", expires_at, created_at, revoked_at\n            FROM user_sessions\n            WHERE id = $1\n            AND revoked_at IS NULL\n            AND expires_at >= NOW()\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "ip_address: IpAddr",
+        "type_info": "Inet"
+      },
+      {
+        "ordinal": 3,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "revoked_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "481d61859d340afb79d632af2c2c5fd47f57dd90a5c311bffdaf65917a7077ef"
+}

--- a/.sqlx/query-82b186062511a0e65d50313f81d8103cb4a67b856e103c9b28dbfbbe6b364e26.json
+++ b/.sqlx/query-82b186062511a0e65d50313f81d8103cb4a67b856e103c9b28dbfbbe6b364e26.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO user_sessions (user_id, ip_address, expires_at)\n            VALUES ($1, $2, $3)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Inet",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "82b186062511a0e65d50313f81d8103cb4a67b856e103c9b28dbfbbe6b364e26"
+}

--- a/.sqlx/query-83052467433e7584c85e669c497fe5e2eab2359a953f5864bc81afe51085e5d8.json
+++ b/.sqlx/query-83052467433e7584c85e669c497fe5e2eab2359a953f5864bc81afe51085e5d8.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, user_id, ip_address as \"ip_address: IpAddr\", expires_at, created_at, revoked_at\n            FROM user_sessions\n            WHERE user_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "ip_address: IpAddr",
+        "type_info": "Inet"
+      },
+      {
+        "ordinal": 3,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "revoked_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "83052467433e7584c85e669c497fe5e2eab2359a953f5864bc81afe51085e5d8"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-client-ip"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ba1af5b620232acf37f2eb6d22151ea465491e0b4c25f552d1990f64ec5a67"
+dependencies = [
+ "axum",
+ "client-ip",
+ "serde",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +302,15 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "client-ip"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d2056bf065c8b4bce5a8898d40e175211ff4410add2a84d695845d3937c729"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -1005,6 +1025,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "axum-client-ip",
  "axum-extra",
  "chrono",
  "derive_more",
@@ -1021,6 +1042,7 @@ dependencies = [
  "tower-sessions",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -2815,6 +2837,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "hashlink",
  "indexmap 2.14.0",
+ "ipnet",
  "log",
  "memchr",
  "once_cell",
@@ -2934,6 +2957,7 @@ dependencies = [
  "hkdf",
  "hmac 0.12.1",
  "home",
+ "ipnet",
  "itoa",
  "log",
  "md-5 0.10.6",
@@ -3502,6 +3526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/hackflare_api/Cargo.toml
+++ b/hackflare_api/Cargo.toml
@@ -20,5 +20,7 @@ serde_with = { version = "3.20.0", features = ["chrono_0_4"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
 axum-extra = { version = "0.12.6", features = ["cookie"] }
-sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "chrono", "ipnet", "uuid"] }
 derive_more = { version = "2.1.1", features = ["full"] }
+axum-client-ip = "1.3.1"
+uuid = { version = "1.23.1", features = ["serde"] }

--- a/hackflare_api/src/config.rs
+++ b/hackflare_api/src/config.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use axum_client_ip::ClientIpSource;
 use derive_more::{Display, Error};
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use reqwest::Url;
@@ -90,6 +91,7 @@ impl HcaConfig {
 #[derive(Debug)]
 pub struct Config {
     pub bind_addr: SocketAddr,
+    pub(crate) client_ip_source: ClientIpSource,
     pub(crate) environment: Environment,
     pub(crate) database_url: Url,
     pub(crate) auto_migrate: bool,
@@ -130,6 +132,7 @@ pub fn from_env() -> Result<Config> {
 
     Ok(Config {
         bind_addr: env_or("API_BIND_ADDR", "0.0.0.0:8080".parse().unwrap())?,
+        client_ip_source: env_or("API_CLIENT_IP_SOURCE", ClientIpSource::ConnectInfo)?,
         database_url,
         auto_migrate,
         environment,

--- a/hackflare_api/src/main.rs
+++ b/hackflare_api/src/main.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, net::SocketAddr};
 
 use anyhow::{Context, Result};
 use dotenv::dotenv;
@@ -21,7 +21,11 @@ async fn run() -> Result<()> {
         .context("failed to set up app state")?;
     let app = build_router(state);
 
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/hackflare_api/src/middlewares/auth.rs
+++ b/hackflare_api/src/middlewares/auth.rs
@@ -12,12 +12,13 @@ use reqwest::StatusCode;
 use crate::{
     config::Config,
     models::{CurrentUser, JwtClaims},
-    services::users::UsersService,
+    services::{user_sessions::UserSessionsService, users::UsersService},
 };
 
 pub(crate) async fn auth_middleware(
     State(config): State<Arc<Config>>,
     State(users): State<UsersService>,
+    State(user_sessions): State<UserSessionsService>,
     jar: CookieJar,
     mut req: Request,
     next: Next,
@@ -44,12 +45,23 @@ pub(crate) async fn auth_middleware(
         warn!("jwt found but no user exists");
         return Err((StatusCode::UNAUTHORIZED, "unauthorized"));
     };
+    debug!(user.id, "got user");
 
+    let session = user_sessions
+        .get_by_id(&claims.jit)
+        .await
+        .map_err(|error| {
+            error!(%error, "failed to get user session");
+            (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
+        })?;
+
+    let Some(session) = session else {
+        debug!(user.id, %claims.jit, "no session found");
+        return Err((StatusCode::UNAUTHORIZED, "unauthorized"));
+    };
     debug!(user.id, "user authenticated");
 
-    let user = CurrentUser { user };
-
-    // TODO: get user data from DB
+    let user = CurrentUser { session, user };
 
     req.extensions_mut().insert(user);
 

--- a/hackflare_api/src/models/db.rs
+++ b/hackflare_api/src/models/db.rs
@@ -1,6 +1,9 @@
+use std::net::IpAddr;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::prelude::*;
+use uuid::Uuid;
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
 pub struct User {
@@ -18,4 +21,16 @@ pub struct User {
     pub hca_access_token: String,
     pub hca_refresh_token: String,
     pub hca_token_expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct UserSession {
+    pub id: Uuid,
+    pub user_id: String,
+    pub ip_address: IpAddr,
+
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+
+    pub revoked_at: Option<DateTime<Utc>>,
 }

--- a/hackflare_api/src/models/mod.rs
+++ b/hackflare_api/src/models/mod.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_with::{TimestampSeconds, serde_as};
+use uuid::Uuid;
 
 pub(crate) mod db;
 
@@ -30,13 +31,15 @@ pub(crate) struct HcaUser {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct JwtClaims {
     pub(crate) sub: String,
+    pub(crate) jit: Uuid,
     #[serde_as(as = "TimestampSeconds<i64>")]
     pub(crate) exp: DateTime<Utc>,
     #[serde_as(as = "TimestampSeconds<i64>")]
     pub(crate) iat: DateTime<Utc>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 pub(crate) struct CurrentUser {
     pub(crate) user: db::User,
+    pub(crate) session: db::UserSession,
 }

--- a/hackflare_api/src/routes/auth.rs
+++ b/hackflare_api/src/routes/auth.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
 };
+use axum_client_ip::ClientIp;
 use chrono::{Duration, Utc};
 use jsonwebtoken::Header;
 use rand::{RngExt, distr::Alphanumeric};
@@ -14,6 +15,7 @@ use reqwest::{StatusCode, Url};
 use serde::Deserialize;
 use serde_json::json;
 use serde_with::{DurationSeconds, serde_as};
+use sqlx::PgPool;
 use tower_sessions::{
     Expiry, MemoryStore, Session, SessionManagerLayer,
     cookie::{self, Cookie, SameSite},
@@ -22,7 +24,7 @@ use tower_sessions::{
 use crate::{
     config::Config,
     models::{HcaUser, JwtClaims},
-    services::users::UsersService,
+    services::{user_sessions::UserSessionsService, users::UsersService},
     state::AppState,
 };
 
@@ -94,6 +96,16 @@ fn random_string(len: usize) -> String {
 const SESSION_CSRF_TOKEN_KEY: &str = "auth::csrf_token";
 const SESSION_TARGET_URL_KEY: &str = "auth::target_url";
 
+// TODO: sliding window sessions via dual-token with separate refresh-token for renewal:
+// - short-lived JWT for most auth (15 minutes)
+// - long-lived refresh JWT to refresh both the short-lived one and itself via `/refresh` (30 days)
+// which automatically slides the window every 15 minutes and only requires a new `/login` when the
+// refresh token expired. the refresh token here represents the actual device session, but means we
+// have short-lived sessions referencing the long-lived ones so that invalidation of a device
+// (logging it out remotely) will invalidate the current session effective immediately
+// => two tables for the sessions
+// => more state
+// => more user convenience (not randomly logged out even if currently active)
 async fn login_handler(
     State(state): State<AppState>,
     session: Session,
@@ -125,9 +137,10 @@ async fn login_handler(
 async fn callback_handler(
     State(config): State<Arc<Config>>,
     State(http_client): State<reqwest::Client>,
-    State(users): State<UsersService>,
+    State(db): State<PgPool>,
     session: Session,
     Query(query): Query<AuthCallbackParams>,
+    ClientIp(ip_addr): ClientIp,
 ) -> Result<Response, (StatusCode, &'static str)> {
     let session_csrf_token: String = session
         .remove(SESSION_CSRF_TOKEN_KEY)
@@ -215,24 +228,44 @@ async fn callback_handler(
     // is harmless, while treating an expired token as valid is a security issue.
     let token_expires_at = token_request_sent_at + token_response.expires_in;
 
-    users
-        .upsert(
-            &user_info,
-            &token_response.access_token,
-            &token_response.refresh_token,
-            token_expires_at,
-        )
+    let mut tx = db.begin().await.map_err(|error| {
+        error!(%error, "failed to start transaction");
+        (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
+    })?;
+
+    UsersService::upsert_with(
+        &mut *tx,
+        &user_info,
+        &token_response.access_token,
+        &token_response.refresh_token,
+        token_expires_at,
+    )
+    .await
+    .map_err(|error| {
+        error!(%error, "failed to upsert user");
+        (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
+    })?;
+
+    let now = Utc::now();
+    let exp = now + chrono::Duration::hours(SESSION_DURATION_HOURS);
+
+    let jit = UserSessionsService::create_with(&mut *tx, &user_info.id, ip_addr, exp)
         .await
         .map_err(|error| {
-            error!(%error, "failed to upsert user");
+            error!(%error, "failed to create session");
             (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
         })?;
 
-    let now = Utc::now();
+    tx.commit().await.map_err(|error| {
+        error!(%error, "failed to commit transaction");
+        (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
+    })?;
+
     let claims = JwtClaims {
         sub: user_info.id,
         iat: now,
-        exp: now + chrono::Duration::hours(SESSION_DURATION_HOURS),
+        jit,
+        exp,
     };
 
     let token = jsonwebtoken::encode(&Header::default(), &claims, &config.jwt_encoding_key)

--- a/hackflare_api/src/routes/mod.rs
+++ b/hackflare_api/src/routes/mod.rs
@@ -4,12 +4,14 @@ use tower_http::trace::TraceLayer;
 use crate::{config::Config, state::AppState};
 
 pub(crate) mod auth;
+pub(crate) mod sessions;
 pub(crate) mod users;
 
 fn v1_routes(state: AppState, config: &Config) -> Router<AppState> {
     Router::new()
         .nest("/auth", auth::routes(config))
-        .nest("/users", users::routes(state))
+        .nest("/users", users::routes(state.clone()))
+        .nest("/sessions", sessions::routes(state))
 }
 
 pub fn build_router(state: AppState) -> Router {

--- a/hackflare_api/src/routes/mod.rs
+++ b/hackflare_api/src/routes/mod.rs
@@ -13,8 +13,10 @@ fn v1_routes(state: AppState, config: &Config) -> Router<AppState> {
 }
 
 pub fn build_router(state: AppState) -> Router {
+    let ip_source_extension = state.config.client_ip_source.clone().into_extension();
     Router::new()
         .nest("/api/v1", v1_routes(state.clone(), &state.config))
         .layer(TraceLayer::new_for_http())
+        .layer(ip_source_extension)
         .with_state(state)
 }

--- a/hackflare_api/src/routes/sessions.rs
+++ b/hackflare_api/src/routes/sessions.rs
@@ -1,0 +1,47 @@
+use axum::{
+    Extension, Json, Router,
+    extract::{Path, State},
+    middleware,
+    routing::get,
+};
+use reqwest::StatusCode;
+use uuid::Uuid;
+
+use crate::{
+    middlewares::auth_middleware,
+    models::{CurrentUser, db::UserSession},
+    services::user_sessions::UserSessionsService,
+    state::AppState,
+};
+
+async fn sessions_handler(
+    Extension(current_user): Extension<CurrentUser>,
+    State(sessions): State<UserSessionsService>,
+) -> Result<Json<Vec<UserSession>>, (StatusCode, &'static str)> {
+    let result = sessions
+        .get_all_for_user(&current_user.user.id)
+        .await
+        .map_err(|error| {
+            error!(%error, "failed to get user sessions");
+            (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
+        })?;
+    Ok(Json(result))
+}
+
+async fn session_by_id_handler(
+    State(sessions): State<UserSessionsService>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Option<UserSession>>, (StatusCode, &'static str)> {
+    let result = sessions.get_by_id(&id).await.map_err(|error| {
+        error!(%error, "failed to get user sessions");
+        (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
+    })?;
+    Ok(Json(result))
+}
+
+pub(super) fn routes(state: AppState) -> Router<AppState> {
+    Router::new()
+        .route("/", get(sessions_handler))
+        .route("/{id}", get(session_by_id_handler))
+        .layer(middleware::from_fn_with_state(state, auth_middleware))
+}

--- a/hackflare_api/src/routes/sessions.rs
+++ b/hackflare_api/src/routes/sessions.rs
@@ -29,14 +29,24 @@ async fn sessions_handler(
 }
 
 async fn session_by_id_handler(
+    Extension(current_user): Extension<CurrentUser>,
     State(sessions): State<UserSessionsService>,
     Path(id): Path<Uuid>,
-) -> Result<Json<Option<UserSession>>, (StatusCode, &'static str)> {
+) -> Result<Json<UserSession>, (StatusCode, &'static str)> {
     let result = sessions.get_by_id(&id).await.map_err(|error| {
         error!(%error, "failed to get user sessions");
         (StatusCode::INTERNAL_SERVER_ERROR, "db_error")
     })?;
-    Ok(Json(result))
+
+    let Some(session) = result else {
+        return Err((StatusCode::NOT_FOUND, "session_not_found"));
+    };
+
+    if session.user_id != current_user.user.id {
+        return Err((StatusCode::FORBIDDEN, "forbidden"));
+    }
+
+    Ok(Json(session))
 }
 
 pub(super) fn routes(state: AppState) -> Router<AppState> {

--- a/hackflare_api/src/services/mod.rs
+++ b/hackflare_api/src/services/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod user_sessions;
 pub(crate) mod users;

--- a/hackflare_api/src/services/user_sessions.rs
+++ b/hackflare_api/src/services/user_sessions.rs
@@ -56,6 +56,26 @@ impl UserSessionsService {
             "#,
             id,
         ).fetch_optional(&self.db).await?;
+
         Ok(session)
+    }
+
+    pub(crate) async fn get_all_for_user(&self, user_id: &str) -> Result<Vec<UserSession>> {
+        let sessions = query_as!(
+            UserSession,
+            r#"
+            SELECT id, user_id, ip_address as "ip_address: IpAddr", expires_at, created_at, revoked_at
+            FROM user_sessions
+            WHERE user_id = $1
+            "#,
+            user_id,
+        ).fetch_all(&self.db).await?;
+
+        // TODO: implement pagination
+        if sessions.len() > 100 {
+            warn!("user sessions count exceeds 100, pagination strongly recommended")
+        }
+
+        Ok(sessions)
     }
 }

--- a/hackflare_api/src/services/user_sessions.rs
+++ b/hackflare_api/src/services/user_sessions.rs
@@ -50,6 +50,8 @@ impl UserSessionsService {
             SELECT id, user_id, ip_address as "ip_address: IpAddr", expires_at, created_at, revoked_at
             FROM user_sessions
             WHERE id = $1
+            AND revoked_at IS NULL
+            AND expires_at >= NOW()
             LIMIT 1
             "#,
             id,

--- a/hackflare_api/src/services/user_sessions.rs
+++ b/hackflare_api/src/services/user_sessions.rs
@@ -1,0 +1,59 @@
+use std::net::IpAddr;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use sqlx::{Executor, PgPool, Postgres, query, query_as};
+use uuid::Uuid;
+
+use crate::models::db::UserSession;
+
+#[derive(Clone)]
+pub(crate) struct UserSessionsService {
+    db: PgPool,
+}
+
+impl UserSessionsService {
+    pub(crate) fn new(db: PgPool) -> Self {
+        Self { db }
+    }
+
+    pub(crate) async fn create_with<'e, E>(
+        executor: E,
+        user_id: &str,
+        ip_address: IpAddr,
+        expires_at: DateTime<Utc>,
+    ) -> Result<Uuid>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let id = query!(
+            r#"
+            INSERT INTO user_sessions (user_id, ip_address, expires_at)
+            VALUES ($1, $2, $3)
+            RETURNING id
+            "#,
+            user_id,
+            ip_address as _,
+            expires_at,
+        )
+        .fetch_one(executor)
+        .await?
+        .id;
+
+        Ok(id)
+    }
+
+    pub(crate) async fn get_by_id(&self, id: &Uuid) -> Result<Option<UserSession>> {
+        let session = query_as!(
+            UserSession,
+            r#"
+            SELECT id, user_id, ip_address as "ip_address: IpAddr", expires_at, created_at, revoked_at
+            FROM user_sessions
+            WHERE id = $1
+            LIMIT 1
+            "#,
+            id,
+        ).fetch_optional(&self.db).await?;
+        Ok(session)
+    }
+}

--- a/hackflare_api/src/services/users.rs
+++ b/hackflare_api/src/services/users.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sqlx::{PgPool, query, query_as};
+use sqlx::{Executor, PgPool, Postgres, query, query_as};
 
 use crate::models::{HcaUser, db::User};
 
@@ -14,13 +14,16 @@ impl UsersService {
         Self { db }
     }
 
-    pub(crate) async fn upsert(
-        &self,
+    pub(crate) async fn upsert_with<'e, E>(
+        executor: E,
         user: &HcaUser,
         access_token: &str,
         refresh_token: &str,
         token_expires_at: DateTime<Utc>,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         query!(
             r#"
             INSERT INTO users (id, email, slack_id, first_name, last_name, verification_status, ysws_eligible, hca_access_token, hca_refresh_token, hca_token_expires_at)
@@ -47,7 +50,7 @@ impl UsersService {
             access_token,
             refresh_token,
             token_expires_at,
-        ).execute(&self.db).await?;
+        ).execute(executor).await?;
 
         Ok(())
     }

--- a/hackflare_api/src/state.rs
+++ b/hackflare_api/src/state.rs
@@ -8,7 +8,10 @@ use sqlx::{
     postgres::PgPoolOptions,
 };
 
-use crate::{config::Config, services::users::UsersService};
+use crate::{
+    config::Config,
+    services::{user_sessions::UserSessionsService, users::UsersService},
+};
 
 static MIGRATOR: Migrator = sqlx::migrate!("../migrations");
 
@@ -20,6 +23,7 @@ pub struct AppState {
 
     // -- services --
     pub(crate) users: UsersService,
+    pub(crate) user_sessions: UserSessionsService,
 }
 
 #[instrument(skip(db))]
@@ -111,12 +115,14 @@ impl AppState {
         migrate_or_verify(&db, &config).await?;
 
         let users = UsersService::new(db.clone());
+        let user_sessions = UserSessionsService::new(db.clone());
 
         Ok(Self {
             config: Arc::new(config),
             http_client,
             db,
             users,
+            user_sessions,
         })
     }
 }

--- a/migrations/20260515180024_create_user_sessions.down.sql
+++ b/migrations/20260515180024_create_user_sessions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE user_sessions;

--- a/migrations/20260515180024_create_user_sessions.up.sql
+++ b/migrations/20260515180024_create_user_sessions.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE user_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+    ip_address INET NOT NULL,
+
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_user_sessions_valid ON user_sessions(user_id)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX idx_user_sessions_cleanup ON user_sessions(
+    LEAST(revoked_at, expires_at)
+);


### PR DESCRIPTION
# Server-side user sessions

This will also allow seeing every currently active session and logging them out for additional security in case a user account is somehow compromised or they loose their device.

## Included
- `user_sessions` table with revocation and audit trail (**TODO:** will be kept e.g. for 1 week, until it's truly deleted in a background job / chron job)
- Session creation on login
- Session validation in auth middleware -- if the session is not in the database, expired, or has been revoked, it's invalid
- `GET /sessions` -- list all active sessions for the current user
- `GET /sessions/{id}` -- get specific session of the current user

## Still missing
- `DELETE /sessions/{id}` -- revoke a specific session
- `DELETE /sessions` -- revoke all sessions (log out all devices)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hack-Flare/codesmith/hackflare/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->