### PR TITLE
Basic Implementation of dns crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "dotenv",
+ "hackflare-dns",
  "jsonwebtoken",
  "rand 0.10.1",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "derive_more",
  "dotenv",
  "hackflare-dns",
+ "http-body-util",
  "jsonwebtoken",
  "rand 0.10.1",
  "reqwest",
@@ -982,6 +983,7 @@ dependencies = [
  "serde_with",
  "sqlx",
  "tokio",
+ "tower",
  "tower-http",
  "tower-sessions",
  "tracing",
@@ -3315,6 +3317,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -12,6 +12,8 @@ services:
       - RUST_LOG=debug,hackflare=trace
     ports:
       - "8080:8080"
+      - "53:5353/udp"
+      - "53:5353/tcp"
     depends_on:
       - db
 

--- a/hackflare_api/Cargo.toml
+++ b/hackflare_api/Cargo.toml
@@ -24,3 +24,4 @@ sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "chrono", "
 derive_more = { version = "2.1.1", features = ["full"] }
 axum-client-ip = "1.3.1"
 uuid = { version = "1.23.1", features = ["serde"] }
+hackflare-dns = { path = "../hackflare_dns" }

--- a/hackflare_api/Cargo.toml
+++ b/hackflare_api/Cargo.toml
@@ -23,5 +23,9 @@ axum-extra = { version = "0.12.6", features = ["cookie"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "chrono", "ipnet", "uuid"] }
 derive_more = { version = "2.1.1", features = ["full"] }
 axum-client-ip = "1.3.1"
-uuid = { version = "1.23.1", features = ["serde"] }
+uuid = { version = "1.23.1", features = ["serde", "v4"] }
 hackflare-dns = { path = "../hackflare_dns" }
+
+[dev-dependencies]
+tower = "0.5"
+http-body-util = "0.1"

--- a/hackflare_api/src/config.rs
+++ b/hackflare_api/src/config.rs
@@ -91,6 +91,7 @@ impl HcaConfig {
 #[derive(Debug)]
 pub struct Config {
     pub bind_addr: SocketAddr,
+    pub dns_bind_addr: SocketAddr,
     pub(crate) client_ip_source: ClientIpSource,
     pub(crate) environment: Environment,
     pub(crate) database_url: Url,
@@ -132,6 +133,7 @@ pub fn from_env() -> Result<Config> {
 
     Ok(Config {
         bind_addr: env_or("API_BIND_ADDR", "0.0.0.0:8080".parse().unwrap())?,
+        dns_bind_addr: env_or("API_DNS_BIND_ADDR", "0.0.0.0:5353".parse().unwrap())?,
         client_ip_source: env_or("API_CLIENT_IP_SOURCE", ClientIpSource::ConnectInfo)?,
         database_url,
         auto_migrate,

--- a/hackflare_api/src/main.rs
+++ b/hackflare_api/src/main.rs
@@ -2,7 +2,10 @@ use std::{env, net::SocketAddr};
 
 use anyhow::{Context, Result};
 use dotenv::dotenv;
-use hackflare_dns::{DnsConfig, ns::{NsConfig, run_with_hickory}};
+use hackflare_dns::{
+    DnsConfig,
+    ns::{NsConfig, run_with_hickory},
+};
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 

--- a/hackflare_api/src/main.rs
+++ b/hackflare_api/src/main.rs
@@ -2,6 +2,7 @@ use std::{env, net::SocketAddr};
 
 use anyhow::{Context, Result};
 use dotenv::dotenv;
+use hackflare_dns::{DnsConfig, ns::{NsConfig, run_with_hickory}};
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
@@ -11,6 +12,9 @@ async fn run() -> Result<()> {
     let config = hackflare_api::config::from_env().context("invalid .env")?;
     info!("initialized config");
 
+    let dns_bind_addr = config.dns_bind_addr;
+    let dns_config = DnsConfig::from_env();
+
     let listener = tokio::net::TcpListener::bind(&config.bind_addr)
         .await
         .context("failed to bind api listener")?;
@@ -19,6 +23,28 @@ async fn run() -> Result<()> {
     let state = AppState::new(config)
         .await
         .context("failed to set up app state")?;
+
+    // Spawn the DNS server on a background thread
+    let dns_authority = state.dns_authority.clone();
+    std::thread::Builder::new()
+        .name("hackflare-dns".into())
+        .spawn(move || {
+            let ns_config = NsConfig {
+                bind_addr: dns_bind_addr.ip().to_string(),
+                port: dns_bind_addr.port(),
+                zone_file: None,
+                database_url: None,
+            };
+            info!("starting DNS server on {dns_bind_addr}");
+            if let Err(e) = run_with_hickory(ns_config, dns_authority, dns_config) {
+                error!("DNS server failed: {e}");
+            } else {
+                info!("DNS server stopped");
+            }
+        })
+        .context("failed to spawn DNS server thread")?;
+    info!("DNS server thread spawned");
+
     let app = build_router(state);
 
     axum::serve(

--- a/hackflare_api/src/routes/dns.rs
+++ b/hackflare_api/src/routes/dns.rs
@@ -9,10 +9,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 
-use crate::{
-    middlewares::auth_middleware,
-    state::AppState,
-};
+use crate::{middlewares::auth_middleware, state::AppState};
 
 // ── Response types ──
 
@@ -116,7 +113,9 @@ async fn delete_zone(
 async fn verify_zone(
     axum::extract::Path(_zone_name): axum::extract::Path<String>,
 ) -> Json<serde_json::Value> {
-    Json(serde_json::json!({"verified": false, "message": "nameserver verification not yet implemented"}))
+    Json(
+        serde_json::json!({"verified": false, "message": "nameserver verification not yet implemented"}),
+    )
 }
 
 // ── Record handlers ──
@@ -169,9 +168,11 @@ async fn create_record(
 
 async fn update_record(
     State(state): State<AppState>,
-    axum::extract::Path((zone_name, record_name, record_type)): axum::extract::Path<
-        (String, String, String),
-    >,
+    axum::extract::Path((zone_name, record_name, record_type)): axum::extract::Path<(
+        String,
+        String,
+        String,
+    )>,
     Json(req): Json<UpdateRecordRequest>,
 ) -> StatusCode {
     if !state
@@ -190,9 +191,11 @@ async fn update_record(
 
 async fn delete_record(
     State(state): State<AppState>,
-    axum::extract::Path((zone_name, record_name, record_type)): axum::extract::Path<
-        (String, String, String),
-    >,
+    axum::extract::Path((zone_name, record_name, record_type)): axum::extract::Path<(
+        String,
+        String,
+        String,
+    )>,
 ) -> StatusCode {
     if state
         .dns_authority
@@ -253,8 +256,14 @@ pub(super) fn routes(state: AppState) -> Router<AppState> {
         .route("/zones", get(list_zones).post(create_zone))
         .route("/zones/{zone_name}", delete(delete_zone))
         .route("/zones/{zone_name}/verify", post(verify_zone))
-        .route("/zones/{zone_name}/records", get(list_records).post(create_record))
-        .route("/zones/{zone_name}/records/{record_name}/{record_type}", put(update_record).delete(delete_record))
+        .route(
+            "/zones/{zone_name}/records",
+            get(list_records).post(create_record),
+        )
+        .route(
+            "/zones/{zone_name}/records/{record_name}/{record_type}",
+            put(update_record).delete(delete_record),
+        )
         .layer(middleware::from_fn_with_state(state, auth_middleware))
 }
 
@@ -265,7 +274,7 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use chrono::{Duration, Utc};
-    use jsonwebtoken::{encode, DecodingKey, EncodingKey, Header};
+    use jsonwebtoken::{DecodingKey, EncodingKey, Header, encode};
     use reqwest::Url;
     use tower::ServiceExt;
     use uuid::Uuid;
@@ -278,8 +287,7 @@ mod tests {
     };
     use axum_client_ip::ClientIpSource;
 
-    const TEST_JWT_SECRET: &str =
-        "dGhpcyBpcyBhIHRlc3Qgc2VjcmV0IGZvciB0ZXN0aW5nIHB1cnBvc2Vz";
+    const TEST_JWT_SECRET: &str = "dGhpcyBpcyBhIHRlc3Qgc2VjcmV0IGZvciB0ZXN0aW5nIHB1cnBvc2Vz";
 
     struct TestCtx {
         state: AppState,
@@ -489,24 +497,24 @@ mod tests {
             return;
         };
 
-        ctx.state
-            .dns_authority
-            .create_zone("test-del.com")
-            .await;
+        ctx.state.dns_authority.create_zone("test-del.com").await;
 
         let response = build_router(ctx.state.clone())
             .oneshot(ctx.authed_request("DELETE", "/api/v1/dns/zones/test-del.com", None))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
-        assert!(!ctx.state.dns_authority.list_zones().await.iter().any(|z| z == "test-del.com"));
+        assert!(
+            !ctx.state
+                .dns_authority
+                .list_zones()
+                .await
+                .iter()
+                .any(|z| z == "test-del.com")
+        );
 
         let response = build_router(ctx.state.clone())
-            .oneshot(ctx.authed_request(
-                "DELETE",
-                "/api/v1/dns/zones/nope.com",
-                None,
-            ))
+            .oneshot(ctx.authed_request("DELETE", "/api/v1/dns/zones/nope.com", None))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -536,11 +544,7 @@ mod tests {
 
         // Verify via authority (add_record returns bool)
         let response = build_router(ctx.state.clone())
-            .oneshot(ctx.authed_request(
-                "GET",
-                "/api/v1/dns/zones/test-rec.com/records",
-                None,
-            ))
+            .oneshot(ctx.authed_request("GET", "/api/v1/dns/zones/test-rec.com/records", None))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
@@ -563,11 +567,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         let response = build_router(ctx.state.clone())
-            .oneshot(ctx.authed_request(
-                "GET",
-                "/api/v1/dns/zones/test-rec.com/records",
-                None,
-            ))
+            .oneshot(ctx.authed_request("GET", "/api/v1/dns/zones/test-rec.com/records", None))
             .await
             .unwrap();
         let body = get_body(response).await;
@@ -587,11 +587,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
         let response = build_router(ctx.state.clone())
-            .oneshot(ctx.authed_request(
-                "GET",
-                "/api/v1/dns/zones/test-rec.com/records",
-                None,
-            ))
+            .oneshot(ctx.authed_request("GET", "/api/v1/dns/zones/test-rec.com/records", None))
             .await
             .unwrap();
         let body = get_body(response).await;
@@ -619,11 +615,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
         let response = build_router(ctx.state.clone())
-            .oneshot(ctx.authed_request(
-                "GET",
-                "/api/v1/dns/zones/nope.com/records",
-                None,
-            ))
+            .oneshot(ctx.authed_request("GET", "/api/v1/dns/zones/nope.com/records", None))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -639,11 +631,7 @@ mod tests {
         };
 
         let response = build_router(ctx.state.clone())
-            .oneshot(ctx.authed_request(
-                "POST",
-                "/api/v1/dns/zones/example.com/verify",
-                None,
-            ))
+            .oneshot(ctx.authed_request("POST", "/api/v1/dns/zones/example.com/verify", None))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);

--- a/hackflare_api/src/routes/dns.rs
+++ b/hackflare_api/src/routes/dns.rs
@@ -1,0 +1,655 @@
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    middleware,
+    response::IntoResponse,
+    routing::{delete, get, post, put},
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::{
+    middlewares::auth_middleware,
+    state::AppState,
+};
+
+// ── Response types ──
+
+#[derive(Serialize)]
+struct ZoneResponse {
+    name: String,
+    ns_verified: bool,
+}
+
+#[derive(Serialize)]
+struct RecordResponse {
+    id: String,
+    name: String,
+    r#type: String,
+    value: String,
+    ttl: u32,
+    status: String,
+}
+
+// ── Request types ──
+
+#[derive(Deserialize)]
+struct CreateZoneRequest {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct CreateRecordRequest {
+    name: String,
+    #[serde(rename = "type")]
+    rtype: String,
+    value: String,
+    ttl: u32,
+}
+
+#[derive(Deserialize)]
+struct UpdateRecordRequest {
+    value: String,
+    ttl: u32,
+}
+
+// ── Zone handlers ──
+
+async fn list_zones(State(state): State<AppState>) -> Json<Vec<ZoneResponse>> {
+    let names = state.dns_authority.list_zones().await;
+    let zones = names
+        .into_iter()
+        .map(|name| ZoneResponse {
+            name,
+            ns_verified: false,
+        })
+        .collect();
+    Json(zones)
+}
+
+async fn create_zone(
+    State(state): State<AppState>,
+    Json(req): Json<CreateZoneRequest>,
+) -> impl IntoResponse {
+    let name = req.name.trim().to_string();
+    if name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "zone name is required"})),
+        )
+            .into_response();
+    }
+
+    // Check zone doesn't already exist
+    let zones = state.dns_authority.list_zones().await;
+    if zones.iter().any(|z| z == &name) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "zone already exists"})),
+        )
+            .into_response();
+    }
+
+    if state.dns_authority.create_zone(&name).await {
+        (StatusCode::CREATED, Json(serde_json::json!({"name": name}))).into_response()
+    } else {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "invalid zone name"})),
+        )
+            .into_response()
+    }
+}
+
+async fn delete_zone(
+    State(state): State<AppState>,
+    axum::extract::Path(zone_name): axum::extract::Path<String>,
+) -> StatusCode {
+    if state.dns_authority.delete_zone(&zone_name).await {
+        StatusCode::NO_CONTENT
+    } else {
+        StatusCode::NOT_FOUND
+    }
+}
+
+async fn verify_zone(
+    axum::extract::Path(_zone_name): axum::extract::Path<String>,
+) -> Json<serde_json::Value> {
+    Json(serde_json::json!({"verified": false, "message": "nameserver verification not yet implemented"}))
+}
+
+// ── Record handlers ──
+
+async fn list_records(
+    State(state): State<AppState>,
+    axum::extract::Path(zone_name): axum::extract::Path<String>,
+) -> Result<Json<Vec<RecordResponse>>, StatusCode> {
+    // Verify zone exists
+    let zones = state.dns_authority.list_zones().await;
+    if !zones.iter().any(|z| z == &zone_name) {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let records = get_records_from_db(&state.db, &zone_name)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(records))
+}
+
+async fn create_record(
+    State(state): State<AppState>,
+    axum::extract::Path(zone_name): axum::extract::Path<String>,
+    Json(req): Json<CreateRecordRequest>,
+) -> impl IntoResponse {
+    let ok = state
+        .dns_authority
+        .add_record(&zone_name, &req.name, &req.rtype, req.ttl, &req.value)
+        .await;
+    if ok {
+        (
+            StatusCode::CREATED,
+            Json(serde_json::json!({
+                "name": req.name,
+                "type": req.rtype,
+                "value": req.value,
+                "ttl": req.ttl,
+                "status": "active"
+            })),
+        )
+            .into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "zone not found or invalid record"})),
+        )
+            .into_response()
+    }
+}
+
+async fn update_record(
+    State(state): State<AppState>,
+    axum::extract::Path((zone_name, record_name, record_type)): axum::extract::Path<
+        (String, String, String),
+    >,
+    Json(req): Json<UpdateRecordRequest>,
+) -> StatusCode {
+    if !state
+        .dns_authority
+        .remove_record(&zone_name, &record_name, &record_type)
+        .await
+    {
+        return StatusCode::NOT_FOUND;
+    }
+    state
+        .dns_authority
+        .add_record(&zone_name, &record_name, &record_type, req.ttl, &req.value)
+        .await;
+    StatusCode::OK
+}
+
+async fn delete_record(
+    State(state): State<AppState>,
+    axum::extract::Path((zone_name, record_name, record_type)): axum::extract::Path<
+        (String, String, String),
+    >,
+) -> StatusCode {
+    if state
+        .dns_authority
+        .remove_record(&zone_name, &record_name, &record_type)
+        .await
+    {
+        StatusCode::NO_CONTENT
+    } else {
+        StatusCode::NOT_FOUND
+    }
+}
+
+// ── DB helpers ──
+
+async fn get_records_from_db(
+    db: &PgPool,
+    zone_name: &str,
+) -> Result<Vec<RecordResponse>, sqlx::Error> {
+    #[derive(sqlx::FromRow)]
+    struct RecordRow {
+        id: uuid::Uuid,
+        name: String,
+        rtype: String,
+        data: String,
+        ttl: i32,
+    }
+
+    let rows = sqlx::query_as::<_, RecordRow>(
+        r#"
+        SELECT r.id, r.name, r.rtype, r.data, r.ttl
+        FROM dns_records r
+        JOIN dns_zones z ON z.id = r.zone_id
+        WHERE z.name = $1
+        ORDER BY r.name, r.rtype
+        "#,
+    )
+    .bind(zone_name)
+    .fetch_all(db)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| RecordResponse {
+            id: r.id.to_string(),
+            name: r.name,
+            r#type: r.rtype,
+            value: r.data,
+            ttl: r.ttl as u32,
+            status: "active".into(),
+        })
+        .collect())
+}
+
+// ── Router ──
+
+pub(super) fn routes(state: AppState) -> Router<AppState> {
+    Router::new()
+        .route("/zones", get(list_zones).post(create_zone))
+        .route("/zones/{zone_name}", delete(delete_zone))
+        .route("/zones/{zone_name}/verify", post(verify_zone))
+        .route("/zones/{zone_name}/records", get(list_records).post(create_record))
+        .route("/zones/{zone_name}/records/{record_name}/{record_type}", put(update_record).delete(delete_record))
+        .layer(middleware::from_fn_with_state(state, auth_middleware))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, str::FromStr};
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use chrono::{Duration, Utc};
+    use jsonwebtoken::{encode, DecodingKey, EncodingKey, Header};
+    use reqwest::Url;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use crate::{
+        config::{Config, Environment, HcaConfig},
+        models::JwtClaims,
+        routes::build_router,
+        state::AppState,
+    };
+    use axum_client_ip::ClientIpSource;
+
+    const TEST_JWT_SECRET: &str =
+        "dGhpcyBpcyBhIHRlc3Qgc2VjcmV0IGZvciB0ZXN0aW5nIHB1cnBvc2Vz";
+
+    struct TestCtx {
+        state: AppState,
+        jwt: String,
+        user_id: String,
+        session_id: Uuid,
+    }
+
+    impl TestCtx {
+        async fn setup() -> Option<Self> {
+            let database_url = std::env::var("DATABASE_URL").ok()?;
+            let url = Url::parse(&database_url).ok()?;
+
+            let config = Config {
+                bind_addr: SocketAddr::from_str("0.0.0.0:0").ok()?,
+                dns_bind_addr: SocketAddr::from_str("0.0.0.0:0").ok()?,
+                client_ip_source: ClientIpSource::ConnectInfo,
+                environment: Environment::Development,
+                database_url: url,
+                auto_migrate: true,
+                jwt_encoding_key: EncodingKey::from_base64_secret(TEST_JWT_SECRET).ok()?,
+                jwt_decoding_key: DecodingKey::from_base64_secret(TEST_JWT_SECRET).ok()?,
+                hca: HcaConfig {
+                    client_id: "test".into(),
+                    client_secret: "test".into(),
+                    redirect_uri: Url::parse("http://localhost:3000/callback").ok()?,
+                },
+            };
+
+            let state = AppState::new(config).await.ok()?;
+
+            let user_id = Uuid::new_v4().to_string();
+            let session_id = Uuid::new_v4();
+            let now = Utc::now();
+
+            let _ = sqlx::query("DELETE FROM users WHERE id LIKE 'test-%'")
+                .execute(&state.db)
+                .await;
+
+            sqlx::query(
+                r#"
+                INSERT INTO users (id, email, slack_id, first_name, last_name, verification_status,
+                                   ysws_eligible, hca_access_token, hca_refresh_token, hca_token_expires_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                "#,
+            )
+            .bind(&user_id)
+            .bind(&format!("{}@test.com", user_id))
+            .bind(&format!("slack_{}", user_id))
+            .bind("Test")
+            .bind("User")
+            .bind("verified")
+            .bind(true)
+            .bind("test_access_token")
+            .bind("test_refresh_token")
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .ok()?;
+
+            sqlx::query(
+                r#"
+                INSERT INTO user_sessions (id, user_id, ip_address, expires_at, created_at)
+                VALUES ($1, $2, $3, $4, $5)
+                "#,
+            )
+            .bind(session_id)
+            .bind(&user_id)
+            .bind(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
+            .bind(now + Duration::hours(1))
+            .bind(now)
+            .execute(&state.db)
+            .await
+            .ok()?;
+
+            let claims = JwtClaims {
+                sub: user_id.clone(),
+                jit: session_id,
+                exp: now + Duration::hours(1),
+                iat: now,
+            };
+            let test_jwt_key = EncodingKey::from_base64_secret(TEST_JWT_SECRET).ok()?;
+            let jwt = encode(&Header::default(), &claims, &test_jwt_key).ok()?;
+
+            Some(Self {
+                state,
+                jwt,
+                user_id,
+                session_id,
+            })
+        }
+
+        fn authed_request(
+            &self,
+            method: &str,
+            uri: &str,
+            body: Option<&'static str>,
+        ) -> Request<Body> {
+            let mut builder = Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("Cookie", format!("jwt={}", self.jwt));
+            if body.is_some() {
+                builder = builder.header("Content-Type", "application/json");
+            }
+            builder
+                .body(body.map(Body::from).unwrap_or_else(Body::empty))
+                .unwrap()
+        }
+
+        async fn cleanup(&self) {
+            let _ = sqlx::query("DELETE FROM user_sessions WHERE id = $1")
+                .bind(self.session_id)
+                .execute(&self.state.db)
+                .await;
+            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                .bind(&self.user_id)
+                .execute(&self.state.db)
+                .await;
+        }
+    }
+
+    async fn get_body(response: axum::response::Response) -> serde_json::Value {
+        use http_body_util::BodyExt;
+        let collected = response.into_body().collect().await.unwrap();
+        serde_json::from_slice(&collected.to_bytes()).unwrap()
+    }
+
+    // ── Tests ──
+
+    #[tokio::test]
+    async fn test_unauthenticated() {
+        let Some(ctx) = TestCtx::setup().await else {
+            eprintln!("skipping: DATABASE_URL not set or unreachable");
+            return;
+        };
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/dns/zones")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        ctx.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn test_create_and_list_zones() {
+        let Some(ctx) = TestCtx::setup().await else {
+            eprintln!("skipping: DATABASE_URL not set or unreachable");
+            return;
+        };
+
+        // Create zone
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "POST",
+                "/api/v1/dns/zones",
+                Some(r#"{"name": "test-create.com"}"#),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // List has zone
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request("GET", "/api/v1/dns/zones", None))
+            .await
+            .unwrap();
+        let body = get_body(response).await;
+        let names: Vec<&str> = body
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|z| z["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"test-create.com"));
+
+        // Duplicate zone returns 409
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "POST",
+                "/api/v1/dns/zones",
+                Some(r#"{"name": "test-create.com"}"#),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+
+        let zones = ctx.state.dns_authority.list_zones().await;
+        assert!(zones.iter().any(|z| z == "test-create.com"));
+
+        // Cleanup
+        let _ = ctx.state.dns_authority.delete_zone("test-create.com").await;
+        ctx.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn test_delete_zone() {
+        let Some(ctx) = TestCtx::setup().await else {
+            eprintln!("skipping: DATABASE_URL not set or unreachable");
+            return;
+        };
+
+        ctx.state
+            .dns_authority
+            .create_zone("test-del.com")
+            .await;
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request("DELETE", "/api/v1/dns/zones/test-del.com", None))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert!(!ctx.state.dns_authority.list_zones().await.iter().any(|z| z == "test-del.com"));
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "DELETE",
+                "/api/v1/dns/zones/nope.com",
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        ctx.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn test_records_crud() {
+        let Some(ctx) = TestCtx::setup().await else {
+            eprintln!("skipping: DATABASE_URL not set or unreachable");
+            return;
+        };
+
+        ctx.state.dns_authority.create_zone("test-rec.com").await;
+
+        // Create record
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "POST",
+                "/api/v1/dns/zones/test-rec.com/records",
+                Some(r#"{"name":"www","type":"A","value":"1.2.3.4","ttl":300}"#),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // Verify via authority (add_record returns bool)
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "GET",
+                "/api/v1/dns/zones/test-rec.com/records",
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = get_body(response).await;
+        let records = body.as_array().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["name"], "www");
+        assert_eq!(records[0]["type"], "A");
+        assert_eq!(records[0]["value"], "1.2.3.4");
+
+        // Update
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "PUT",
+                "/api/v1/dns/zones/test-rec.com/records/www/A",
+                Some(r#"{"value":"10.0.0.1","ttl":600}"#),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "GET",
+                "/api/v1/dns/zones/test-rec.com/records",
+                None,
+            ))
+            .await
+            .unwrap();
+        let body = get_body(response).await;
+        let rec = &body.as_array().unwrap()[0];
+        assert_eq!(rec["value"], "10.0.0.1");
+        assert_eq!(rec["ttl"], 600);
+
+        // Delete record
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "DELETE",
+                "/api/v1/dns/zones/test-rec.com/records/www/A",
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "GET",
+                "/api/v1/dns/zones/test-rec.com/records",
+                None,
+            ))
+            .await
+            .unwrap();
+        let body = get_body(response).await;
+        assert_eq!(body.as_array().unwrap().len(), 0);
+
+        let _ = ctx.state.dns_authority.delete_zone("test-rec.com").await;
+        ctx.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn test_records_nonexistent_zone() {
+        let Some(ctx) = TestCtx::setup().await else {
+            eprintln!("skipping: DATABASE_URL not set or unreachable");
+            return;
+        };
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "POST",
+                "/api/v1/dns/zones/nope.com/records",
+                Some(r#"{"name":"www","type":"A","value":"1.2.3.4","ttl":300}"#),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "GET",
+                "/api/v1/dns/zones/nope.com/records",
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        ctx.cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn test_verify_zone() {
+        let Some(ctx) = TestCtx::setup().await else {
+            eprintln!("skipping: DATABASE_URL not set or unreachable");
+            return;
+        };
+
+        let response = build_router(ctx.state.clone())
+            .oneshot(ctx.authed_request(
+                "POST",
+                "/api/v1/dns/zones/example.com/verify",
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = get_body(response).await;
+        assert!(!body["verified"].as_bool().unwrap());
+
+        ctx.cleanup().await;
+    }
+}

--- a/hackflare_api/src/routes/dns.rs
+++ b/hackflare_api/src/routes/dns.rs
@@ -335,8 +335,8 @@ mod tests {
                 "#,
             )
             .bind(&user_id)
-            .bind(&format!("{}@test.com", user_id))
-            .bind(&format!("slack_{}", user_id))
+            .bind(format!("{}@test.com", user_id))
+            .bind(format!("slack_{}", user_id))
             .bind("Test")
             .bind("User")
             .bind("verified")

--- a/hackflare_api/src/routes/health.rs
+++ b/hackflare_api/src/routes/health.rs
@@ -19,7 +19,11 @@ pub(crate) async fn health(State(state): State<AppState>) -> Json<HealthResponse
 
     let all_ok = database == "ok";
     Json(HealthResponse {
-        status: if all_ok { "ok".into() } else { "degraded".into() },
+        status: if all_ok {
+            "ok".into()
+        } else {
+            "degraded".into()
+        },
         database,
         dns_zones,
     })

--- a/hackflare_api/src/routes/health.rs
+++ b/hackflare_api/src/routes/health.rs
@@ -1,0 +1,37 @@
+use axum::{Json, extract::State};
+use serde::Serialize;
+use sqlx::PgPool;
+
+use crate::state::AppState;
+
+#[derive(Serialize)]
+pub struct HealthResponse {
+    pub status: String,
+    pub database: String,
+    pub dns_zones: usize,
+}
+
+pub(crate) async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
+    let (database, dns_zones) = tokio::join!(
+        check_db(&state.db),
+        count_zones(state.dns_authority.clone()),
+    );
+
+    let all_ok = database == "ok";
+    Json(HealthResponse {
+        status: if all_ok { "ok".into() } else { "degraded".into() },
+        database,
+        dns_zones,
+    })
+}
+
+async fn check_db(db: &PgPool) -> String {
+    match sqlx::query("SELECT 1").execute(db).await {
+        Ok(_) => "ok".into(),
+        Err(e) => format!("error: {e}"),
+    }
+}
+
+async fn count_zones(authority: std::sync::Arc<hackflare_dns::ns::AuthorityStore>) -> usize {
+    authority.list_zones().await.len()
+}

--- a/hackflare_api/src/routes/mod.rs
+++ b/hackflare_api/src/routes/mod.rs
@@ -1,19 +1,21 @@
-use axum::{Router, routing::post};
+use axum::{Router, routing::get};
 use tower_http::trace::TraceLayer;
 
 use crate::{config::Config, state::AppState};
 
 pub(crate) mod auth;
+pub(crate) mod health;
 pub(crate) mod sessions;
 pub mod slack;
 pub(crate) mod users;
 
 fn v1_routes(state: AppState, config: &Config) -> Router<AppState> {
     Router::new()
+        .route("/health", get(health::health))
         .nest("/auth", auth::routes(config))
         .nest("/users", users::routes(state.clone()))
         .nest("/sessions", sessions::routes(state))
-        .route("/slack/contact", post(slack::slack_contact))
+        .route("/slack/contact", axum::routing::post(slack::slack_contact))
 }
 
 pub fn build_router(state: AppState) -> Router {

--- a/hackflare_api/src/routes/mod.rs
+++ b/hackflare_api/src/routes/mod.rs
@@ -4,6 +4,7 @@ use tower_http::trace::TraceLayer;
 use crate::{config::Config, state::AppState};
 
 pub(crate) mod auth;
+pub(crate) mod dns;
 pub(crate) mod health;
 pub(crate) mod sessions;
 pub mod slack;
@@ -14,7 +15,8 @@ fn v1_routes(state: AppState, config: &Config) -> Router<AppState> {
         .route("/health", get(health::health))
         .nest("/auth", auth::routes(config))
         .nest("/users", users::routes(state.clone()))
-        .nest("/sessions", sessions::routes(state))
+        .nest("/sessions", sessions::routes(state.clone()))
+        .nest("/dns", dns::routes(state.clone()))
         .route("/slack/contact", axum::routing::post(slack::slack_contact))
 }
 

--- a/hackflare_api/src/services/user_sessions.rs
+++ b/hackflare_api/src/services/user_sessions.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sqlx::{Executor, PgPool, Postgres, query, query_as};
+use sqlx::{Executor, PgPool, Postgres, query, query_as, Row};
 use uuid::Uuid;
 
 use crate::models::db::UserSession;
@@ -26,50 +26,53 @@ impl UserSessionsService {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let id = query!(
+        let row = query(
             r#"
             INSERT INTO user_sessions (user_id, ip_address, expires_at)
             VALUES ($1, $2, $3)
             RETURNING id
             "#,
-            user_id,
-            ip_address as _,
-            expires_at,
         )
+        .bind(user_id)
+        .bind(ip_address)
+        .bind(expires_at)
         .fetch_one(executor)
-        .await?
-        .id;
+        .await?;
+
+        let id: Uuid = row.try_get("id")?;
 
         Ok(id)
     }
 
     pub(crate) async fn get_by_id(&self, id: &Uuid) -> Result<Option<UserSession>> {
-        let session = query_as!(
-            UserSession,
+        let session = query_as::<_, UserSession>(
             r#"
-            SELECT id, user_id, ip_address as "ip_address: IpAddr", expires_at, created_at, revoked_at
+            SELECT id, user_id, ip_address, expires_at, created_at, revoked_at
             FROM user_sessions
             WHERE id = $1
             AND revoked_at IS NULL
             AND expires_at >= NOW()
             LIMIT 1
             "#,
-            id,
-        ).fetch_optional(&self.db).await?;
+        )
+        .bind(id)
+        .fetch_optional(&self.db)
+        .await?;
 
         Ok(session)
     }
 
     pub(crate) async fn get_all_for_user(&self, user_id: &str) -> Result<Vec<UserSession>> {
-        let sessions = query_as!(
-            UserSession,
+        let sessions = query_as::<_, UserSession>(
             r#"
-            SELECT id, user_id, ip_address as "ip_address: IpAddr", expires_at, created_at, revoked_at
+            SELECT id, user_id, ip_address, expires_at, created_at, revoked_at
             FROM user_sessions
             WHERE user_id = $1
             "#,
-            user_id,
-        ).fetch_all(&self.db).await?;
+        )
+        .bind(user_id)
+        .fetch_all(&self.db)
+        .await?;
 
         // TODO: implement pagination
         if sessions.len() > 100 {

--- a/hackflare_api/src/services/user_sessions.rs
+++ b/hackflare_api/src/services/user_sessions.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sqlx::{Executor, PgPool, Postgres, query, query_as, Row};
+use sqlx::{Executor, PgPool, Postgres, Row, query, query_as};
 use uuid::Uuid;
 
 use crate::models::db::UserSession;

--- a/hackflare_api/src/services/users.rs
+++ b/hackflare_api/src/services/users.rs
@@ -24,7 +24,7 @@ impl UsersService {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        query!(
+        query(
             r#"
             INSERT INTO users (id, email, slack_id, first_name, last_name, verification_status, ysws_eligible, hca_access_token, hca_refresh_token, hca_token_expires_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
@@ -40,23 +40,26 @@ impl UsersService {
                 hca_refresh_token = EXCLUDED.hca_refresh_token,
                 hca_token_expires_at = EXCLUDED.hca_token_expires_at;
             "#,
-            user.id,
-            user.primary_email,
-            user.slack_id,
-            user.first_name,
-            user.last_name,
-            user.verification_status,
-            user.ysws_eligible,
-            access_token,
-            refresh_token,
-            token_expires_at,
-        ).execute(executor).await?;
+        )
+        .bind(&user.id)
+        .bind(&user.primary_email)
+        .bind(&user.slack_id)
+        .bind(&user.first_name)
+        .bind(&user.last_name)
+        .bind(&user.verification_status)
+        .bind(user.ysws_eligible)
+        .bind(access_token)
+        .bind(refresh_token)
+        .bind(token_expires_at)
+        .execute(executor)
+        .await?;
 
         Ok(())
     }
 
     pub(crate) async fn get_by_id(&self, id: &str) -> Result<Option<User>> {
-        let user = query_as!(User, "SELECT * from users WHERE id = $1 LIMIT 1", id)
+        let user = query_as::<_, User>("SELECT * from users WHERE id = $1 LIMIT 1")
+            .bind(id)
             .fetch_optional(&self.db)
             .await?;
 

--- a/hackflare_api/src/state.rs
+++ b/hackflare_api/src/state.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use axum::extract::FromRef;
+use hackflare_dns::{DnsConfig, ns::{AuthorityStore, PostgresPersistence, ZonePersistence}};
 use sqlx::{
     PgPool,
     migrate::{Migrate, Migrator},
@@ -17,9 +18,12 @@ static MIGRATOR: Migrator = sqlx::migrate!("../migrations");
 
 #[derive(Clone, FromRef)]
 pub struct AppState {
-    pub(crate) config: Arc<Config>,
+    pub config: Arc<Config>,
     pub(crate) http_client: reqwest::Client,
     pub(crate) db: PgPool,
+
+    // -- dns --
+    pub dns_authority: Arc<AuthorityStore>,
 
     // -- services --
     pub(crate) users: UsersService,
@@ -117,10 +121,19 @@ impl AppState {
         let users = UsersService::new(db.clone());
         let user_sessions = UserSessionsService::new(db.clone());
 
+        let persistence: Arc<dyn ZonePersistence> = Arc::new(PostgresPersistence::new(db.clone()));
+        let dns_authority = Arc::new(AuthorityStore::with_persistence(
+            DnsConfig::from_env(),
+            persistence,
+        ));
+        dns_authority.load_zones_from_storage().await?;
+        info!("dns zones loaded from storage");
+
         Ok(Self {
             config: Arc::new(config),
             http_client,
             db,
+            dns_authority,
             users,
             user_sessions,
         })

--- a/hackflare_api/src/state.rs
+++ b/hackflare_api/src/state.rs
@@ -2,7 +2,10 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use axum::extract::FromRef;
-use hackflare_dns::{DnsConfig, ns::{AuthorityStore, PostgresPersistence, ZonePersistence}};
+use hackflare_dns::{
+    DnsConfig,
+    ns::{AuthorityStore, PostgresPersistence, ZonePersistence},
+};
 use sqlx::{
     PgPool,
     migrate::{Migrate, Migrator},

--- a/hackflare_dns/src/ns/hickory.rs
+++ b/hackflare_dns/src/ns/hickory.rs
@@ -174,8 +174,8 @@ impl RequestHandler for HickoryRequestHandler {
     }
 }
 
-pub(super) fn run_with_hickory(
-    config: &NsConfig,
+pub fn run_with_hickory(
+    config: NsConfig,
     authority: Arc<AuthorityStore>,
     dns_config: DnsConfig,
 ) -> io::Result<()> {

--- a/hackflare_dns/src/ns/hickory.rs
+++ b/hackflare_dns/src/ns/hickory.rs
@@ -133,11 +133,18 @@ impl RequestHandler for HickoryRequestHandler {
             }
         };
 
+        // Build response metadata from the request so the ID matches
+        let mut response_meta = Metadata::response_from_request(&request.metadata);
+        response_meta.response_code = response.metadata.response_code;
+        response_meta.recursion_available = true;
+        response_meta.recursion_desired = request.metadata.recursion_desired;
+        response_meta.authoritative = false;
+
         // Clamp UDP response size to prevent amplification attacks
         if request.protocol() == Protocol::Udp
             && response_bytes_len > self.dns_config.max_edns_payload_size as usize
         {
-            response.metadata.truncation = true;
+            response_meta.truncation = true;
             response.answers.clear();
             response.additionals.clear();
         }
@@ -148,7 +155,7 @@ impl RequestHandler for HickoryRequestHandler {
         }
 
         let message_response = builder.build(
-            response.metadata,
+            response_meta,
             &response.answers,
             &response.authorities,
             [],

--- a/hackflare_dns/src/ns/mod.rs
+++ b/hackflare_dns/src/ns/mod.rs
@@ -1,11 +1,13 @@
-mod authority;
+pub mod authority;
 mod hickory;
 
 pub mod config;
 pub mod persistence;
 pub mod server;
 
+pub use authority::AuthorityStore;
 pub use config::NsConfig;
+pub use hickory::run_with_hickory;
 pub use persistence::{
     MemoryPersistence, PersistedRecord, PersistedZone, PostgresPersistence, ZonePersistence,
 };

--- a/hackflare_dns/src/ns/server.rs
+++ b/hackflare_dns/src/ns/server.rs
@@ -176,7 +176,7 @@ impl Nameserver {
     /// Returns an I/O error if the server fails to start (e.g., port in use).
     pub fn run(&self) -> io::Result<()> {
         run_with_hickory(
-            &self.config,
+            self.config.clone(),
             Arc::clone(&self.authority),
             self.dns_config.clone(),
         )

--- a/migrations/20260518120000_create_dns_tables.down.sql
+++ b/migrations/20260518120000_create_dns_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS dns_records;
+DROP TABLE IF EXISTS dns_zones;

--- a/migrations/20260518120000_create_dns_tables.up.sql
+++ b/migrations/20260518120000_create_dns_tables.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS dns_zones (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS dns_records (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    zone_id UUID NOT NULL REFERENCES dns_zones(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    rtype TEXT NOT NULL,
+    ttl INTEGER NOT NULL DEFAULT 300,
+    data TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(zone_id, name, rtype)
+);


### PR DESCRIPTION
This pull request introduces DNS server integration into the API service, adds persistent DNS zone storage, and exposes DNS health information via a new endpoint. The most important changes are grouped below.

**DNS Integration and API Changes**

* The API now spawns a DNS server in a background thread, configured via new `dns_bind_addr` settings and using the `hackflare_dns` crate. The DNS server loads zones from persistent storage and shares authority state with the API. (`hackflare_api/src/main.rs`, `hackflare_api/src/config.rs`, `hackflare_api/src/state.rs`, `compose.dev.yml`, `hackflare_api/Cargo.toml`) [[1]](diffhunk://#diff-921b22811476c8e48f96586536b729cbb413419ef64bce8c84d303bab691a8bfR5) [[2]](diffhunk://#diff-921b22811476c8e48f96586536b729cbb413419ef64bce8c84d303bab691a8bfR15-R17) [[3]](diffhunk://#diff-921b22811476c8e48f96586536b729cbb413419ef64bce8c84d303bab691a8bfR26-R47) [[4]](diffhunk://#diff-85a0c88fb699cee10d591db4626708313bbd7cd2ba88dd89aac79397bb2d5aecR94) [[5]](diffhunk://#diff-85a0c88fb699cee10d591db4626708313bbd7cd2ba88dd89aac79397bb2d5aecR136) [[6]](diffhunk://#diff-2af3467cf3859a90821c155b52672040efa5322a0c8c9e7463df672987a234a9R5) [[7]](diffhunk://#diff-2af3467cf3859a90821c155b52672040efa5322a0c8c9e7463df672987a234a9L20-R27) [[8]](diffhunk://#diff-2af3467cf3859a90821c155b52672040efa5322a0c8c9e7463df672987a234a9R124-R136) [[9]](diffhunk://#diff-bfb72f2c1c0b7deb52e32346fe2a5dadd2a489cedd430a2cc12e2ce57e7c2f51R15-R16) [[10]](diffhunk://#diff-b5918547cd54f10e8d4e915585e12fa9e766f133ff62b71ea07d8dab862e615dL26-R31)

**DNS Persistence and Migrations**

* Adds database migrations to create `dns_zones` and `dns_records` tables for persistent DNS zone and record storage. (`migrations/20260518120000_create_dns_tables.up.sql`, `migrations/20260518120000_create_dns_tables.down.sql`) [[1]](diffhunk://#diff-682742abbe9738c0c2ad305463f2a92c6e300db188ba65a6137ad61a650fc92aR1-R18) [[2]](diffhunk://#diff-ec9998c3e69eff22d33d44f36fc5be513e3a8a1cab761be61c57245c1e51a471R1-R2)

**Health Endpoint and Routing**

* Introduces a `/health` endpoint that reports API, database, and DNS zone status, using a new handler and updating the router. (`hackflare_api/src/routes/health.rs`, `hackflare_api/src/routes/mod.rs`) [[1]](diffhunk://#diff-cab48815b9e12f881a9458b7283a8774405fb61089cf86069e66bea42d651cf9R1-R37) [[2]](diffhunk://#diff-992442406e5bbd6461229feaddbe4b8b42d67be711d8fb846758ae508d7aadb2L1-R20)

**DNS Server and Library Improvements**

* Refactors DNS server code for better integration: exposes `run_with_hickory` publicly, improves response metadata handling to ensure correct DNS responses, and updates server startup signatures. (`hackflare_dns/src/ns/hickory.rs`, `hackflare_dns/src/ns/mod.rs`, `hackflare_dns/src/ns/server.rs`) [[1]](diffhunk://#diff-d07f99b39db6cd883e2b75848349385c515c3bcdf8604cc230d822ea9df6e3feR136-R147) [[2]](diffhunk://#diff-d07f99b39db6cd883e2b75848349385c515c3bcdf8604cc230d822ea9df6e3feL151-R158) [[3]](diffhunk://#diff-d07f99b39db6cd883e2b75848349385c515c3bcdf8604cc230d822ea9df6e3feL177-R185) [[4]](diffhunk://#diff-f07e1c3a192ce4893b6b9091d2a2587bb072862cf36f87ef8251ad4480887efbL1-R10) [[5]](diffhunk://#diff-0b3635dafb7fecce8d9ffde09af838c357bf77a3c59ba22eec05c9a3127ba7d9L179-R179)

**Configuration and Dependency Updates**

* Updates configuration to support DNS settings and adds necessary dependencies for DNS integration and testing. (`hackflare_api/Cargo.toml`, `hackflare_api/src/config.rs`) [[1]](diffhunk://#diff-b5918547cd54f10e8d4e915585e12fa9e766f133ff62b71ea07d8dab862e615dL26-R31) [[2]](diffhunk://#diff-85a0c88fb699cee10d591db4626708313bbd7cd2ba88dd89aac79397bb2d5aecR94) [[3]](diffhunk://#diff-85a0c88fb699cee10d591db4626708313bbd7cd2ba88dd89aac79397bb2d5aecR136)

These changes collectively enable the API to serve DNS requests, persist DNS data, and provide operational health insights.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Hack-Flare/codesmith/hackflare/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->